### PR TITLE
Take the directory name as the project name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+/.idea/

--- a/lib/handy/heroku_helpers.rb
+++ b/lib/handy/heroku_helpers.rb
@@ -43,7 +43,7 @@ namespace :handy do
     end
 
     def heroku_app_name t, args
-      args[:app] || ENV['APP_NAME'] || abort(<<ERROR_MSG)
+      args[:app] || ENV['APP_NAME'] || Rails.root.basename || abort(<<ERROR_MSG)
 Error: heroku app name is missing. This rake task should be invoked like this:
 
   rake #{t.name}['tweli'].


### PR DESCRIPTION
```
nsingh ~/dev/brightfunds_inc/brightfunds 1.9.3(Bright-Funds)(pg)
$ rake handy:heroku:prod2development
Error: heroku app name is missing. This rake task should be invoked like this:

  rake handy:heroku:prod2development['tweli'].

```

In this case I should not have to provide project name since the project name can be guessed from the current directory name. I should provide project name only if I want to override the project name that is coming from the directory name.
