### PR TITLE
Change default formatter for Rails for better logging of exceptions.

### DIFF
--- a/lib/handy.rb
+++ b/lib/handy.rb
@@ -3,4 +3,6 @@ require "handy/engine"
 
 module Handy
   autoload :ConfigLoader, 'handy/config_loader'
+  autoload :SimpleFormatter, 'handy/simple_formatter'
 end
+

--- a/lib/handy/engine.rb
+++ b/lib/handy/engine.rb
@@ -5,6 +5,20 @@ module Handy
       ::Settings = ConfigLoader.new('settings.yml').load
     end
 
+    initializer :setup_formatter, after: :initialize_logger do
+      begin
+        if Rails.logger.respond_to?(:formatter=)
+          Rails.logger.formatter = SimpleFormatter.new
+        elsif Rails.version < "4.0"
+          Rails.logger.instance_variable_get(:@logger)
+          .instance_variable_get(:@log)
+          .formatter = SimpleFormatter.new
+        end
+      rescue
+        #do nothing
+      end
+    end
+
     rake_tasks do
       load 'handy/trailing_whitespaces.rb'
       load 'handy/delete_merged_branches.rb'

--- a/lib/handy/simple_formatter.rb
+++ b/lib/handy/simple_formatter.rb
@@ -1,0 +1,11 @@
+require 'logger'
+module Handy
+  class SimpleFormatter < ::Logger::Formatter
+    # This method is invoked when a log event occurs
+    # Override it to match exception display from Ruby Formatter.
+    def call(severity, timestamp, progname, msg)
+      "#{msg2str(msg)}"
+    end
+  end
+
+end


### PR DESCRIPTION
Default Rails Formatter logs messages using

``` ruby
 "#{String === msg ? msg : msg.inspect}\n"
```

 This is painful when logging Exceptions in descriptive fashion , which ruby's default logger does with-

``` ruby

      case msg
      when ::String
        msg
      when ::Exception
        "#{ msg.message } (#{ msg.class })\n" <<
          (msg.backtrace || []).join("\n")
      else
        msg.inspect
      end

```

lets use this in case for default formatting.

Handles cases for `ActiveSupport::Logger` and deprecated `ActiveSupport::BufferedLogger` for Applications before Rails 4.0
