### PR TITLE
 Added rake task for setting up database.yml

### DIFF
--- a/lib/handy/add_database_yml.rb
+++ b/lib/handy/add_database_yml.rb
@@ -1,0 +1,79 @@
+namespace :handy do
+
+  def git_branch_command
+    "git_branch = `git symbolic-ref HEAD 2>/dev/null`.chomp.sub('refs/heads/', '')"
+  end
+
+  def repository_name_command
+    "repository_name = `git rev-parse --show-toplevel`.split('/').last.strip"
+  end
+
+  def database_name(env)
+    case env
+    when 'development'
+      '<%= "#{repository_name}_development"[0...63] %>'
+    when 'test'
+      '<%= "#{repository_name}_test"[0...63] %>'
+    end
+  end
+
+  def database_yml_path
+    File.join Rails.root, 'config', 'database.yml'
+  end
+
+  def adapter
+    ENV['ADAPTER'] = 'mysql2' if ENV['ADAPTER'] == 'mysql'
+    @_adapter ||= ENV['ADAPTER'] || 'postgresql'
+  end
+
+  def adapter_credentials
+    case adapter
+    when 'postgresql'
+      { 'username' => 'postgres', 'password' => nil }
+    when 'sqlite3'
+      {}
+    when 'mysql2'
+      { 'username' => 'root', 'password' => nil }
+    else
+      raise "Adapter #{adapter} is not supported."
+    end
+  end
+
+  def db_character_set
+    case adapter
+    when 'postgresql'
+      'unicode'
+    when 'sqlite3'
+      nil
+    when 'mysql', 'mysql2'
+      'utf8'
+    else
+      raise "Adapter #{adapter} is not supported."
+    end
+  end
+
+  def config(env)
+    { env => { 'adapter'  => adapter,
+               'database' => database_name(env),
+               'encoding' => db_character_set,
+               'host'     => 'localhost',
+               'pool'     => 5
+             }.merge(adapter_credentials)
+    }
+  end
+
+  desc 'Creates database.yml. Default adapter is postgresql. Uses repository name and environment for generating database name. Options: (ADAPTER: sqlite3/mysql2/postgresql)'
+  task :add_database_yml do
+    File.open database_yml_path, 'w' do |f|
+      f.write "<% #{git_branch_command} %>\n"
+      f.write "<% #{repository_name_command} %>\n"
+      f.write "\n"
+      f.write "# Database name is restricted to 63 characters.\n"
+      f.write "# Because the default limit on length of identifiers in PostGreSQL is 63.\n"
+      f.write "\n"
+      f.write config('development').to_yaml.gsub(/^---\s+/, '')
+      f.write "\n"
+      f.write config('test').to_yaml.gsub(/^---\s+/, '')
+    end
+  end
+end

--- a/lib/handy/engine.rb
+++ b/lib/handy/engine.rb
@@ -11,8 +11,8 @@ module Handy
       load 'handy/heroku_tasks.rb'
       load 'handy/additional_test_directories.rb'
       load 'handy/delete_heroku_apps.rb'
+      load 'handy/add_database_yml.rb'
     end
 
   end
 end
-


### PR DESCRIPTION
- By default it will setup database.yml with postgresql as database.
- Different adapter can be passed using ADAPTER ENV variable, and then
  database.yml for particular adapter will be setup.
- Connection pool size can also be configured using POOL_SIZE ENV
  variable.
- Right now supports only MRI database adapters sqlite3, mysql, mysql2
  and postgresql.
