### PR TITLE
Fix heroku database copy and restore tasks

### DIFF
--- a/lib/handy/heroku_tasks.rb
+++ b/lib/handy/heroku_tasks.rb
@@ -56,7 +56,6 @@ namespace :handy do
       if a.nil?
         puts "A was not supplied"
         puts "Usage: rake handy:heroku:a2b A=production B=533-home-page-design--ip"
-        puts "       heroku addons:add pgbackups --app demo-533-home-page-design--ip"
         puts "       Also ensure that you have access to this application"
         exit 1
       end

--- a/lib/handy/heroku_tasks.rb
+++ b/lib/handy/heroku_tasks.rb
@@ -44,8 +44,8 @@ namespace :handy do
       src_app_name = "#{heroku_app_name}-production"
       dst_app_name = "#{heroku_app_name}-staging"
 
-      get_src_db_url_cmd = "`heroku pgbackups:url --app #{src_app_name}`"
-      execute "heroku pgbackups:restore DATABASE #{get_src_db_url_cmd} --app #{dst_app_name} --confirm #{dst_app_name}"
+      get_src_db_url_cmd = "`heroku pg:backups public-url --app #{src_app_name}`"
+      execute "heroku pg:backups restore #{get_src_db_url_cmd} DATABASE --app #{dst_app_name} --confirm #{dst_app_name}"
     end
 
     desc "Take snapshot of branch A and copy data to branch B"
@@ -73,8 +73,8 @@ namespace :handy do
       src_app_name = "#{heroku_app_name}-#{a}"
       dst_app_name = "#{heroku_app_name}-#{b}"
 
-      get_src_db_url_cmd = "`heroku pgbackups:url --app #{src_app_name}`"
-      execute "heroku pgbackups:restore DATABASE #{get_src_db_url_cmd} --app #{dst_app_name} --confirm #{dst_app_name}"
+      get_src_db_url_cmd = "`heroku pg:backups public-url --app #{src_app_name}`"
+      execute "heroku pg:backups restore #{get_src_db_url_cmd} DATABASE --app #{dst_app_name} --confirm #{dst_app_name}"
     end
 
     def export2local(app_name)

--- a/lib/handy/version.rb
+++ b/lib/handy/version.rb
@@ -1,3 +1,3 @@
 module Handy
-  VERSION = "0.0.32"
+  VERSION = "0.0.33"
 end


### PR DESCRIPTION
- Heroku API related to backup and restore database is changed.
- This commit fixes some of the outdated commands used for backing up
  and restoring database from one app to other.
- More details - https://devcenter.heroku.com/articles/heroku-postgres-backups