### PR TITLE
Load Settings from settings.yml if this file is present in the project

### DIFF
--- a/lib/handy/engine.rb
+++ b/lib/handy/engine.rb
@@ -1,6 +1,13 @@
 module Handy
   class Engine < ::Rails::Engine
 
+    initializer :load_application_yml, before: :load_environment_config do
+      settings_file = Rails.root.join('config', 'settings.yml')
+      if File.exist?(settings_file)
+        ::Settings = ConfigLoader.new('settings.yml').load
+      end
+    end
+
     rake_tasks do
       load 'handy/trailing_whitespaces.rb'
       load 'handy/delete_merged_branches.rb'


### PR DESCRIPTION
- This gives old projects which are using `Settings` ability to use
  latest version of handy.
- In new projects, we have already removed `settings.yml` from `config`
  folder.
- So this can be workable compromise for old as well as new apps.